### PR TITLE
Add runtime normalization to z-estimation code; fix the bug of runtime z_qso samples generation

### DIFF
--- a/process_qsos.m
+++ b/process_qsos.m
@@ -2,7 +2,7 @@
 
 % load QSO model from training release
 variables_to_load = {'rest_wavelengths', 'mu', 'M'};
-load(sprintf('%s/learned_qso_model_%s',             ...
+load(sprintf('%s/learned_zqso_only_model_%s',             ...
     processed_directory(training_release), ...
     training_set_name),                    ...
     variables_to_load{:});
@@ -11,10 +11,12 @@ load(sprintf('%s/learned_qso_model_%s',             ...
 catalog = load(sprintf('%s/zqso_only_catalog', processed_directory(release)));
 
 z_qsos = catalog.z_qsos;
-% Generate samples with different quasar redshifts
-max_z_qso = max(catalog.z_qsos);
-offset_samples_qso = 1:num_zqso_samples;
-offset_samples_qso = z_qso_cut + (offset_samples_qso - 1) * (max_z_qso - z_qso_cut)/num_zqso_samples;
+
+rng('default');
+sequence = scramble(haltonset(1), 'rr2');
+
+% ADDING: dimension for z_qso
+offset_samples_qso  = sequence(1:num_zqso_samples, 1)';
 
 bins = 150;
 [z_freq, z_bin] = histcounts(z_qsos, [z_qso_cut : ((max(z_qsos) - z_qso_cut) / bins) : max(z_qsos)]);
@@ -42,6 +44,11 @@ all_thing_ids      =   catalog.thing_ids(test_ind);
 z_qsos = catalog.z_qsos(test_ind);
 
 num_quasars = numel(z_qsos);
+if exist('qso_ind', 'var') == 0
+    qso_ind = 1:1:floor(num_quasars/100);
+end
+num_quasars = numel(qso_ind);
+
 %load('./test/M.mat');
 % preprocess model interpolants
 mu_interpolator = ...
@@ -51,6 +58,7 @@ M_interpolator = ...
 
 % initialize results
 sample_log_posteriors  = nan(num_quasars, num_zqso_samples);
+z_true                        = nan(num_quasars, 1);
 z_map                         = nan(num_quasars, 1);
 signal_to_noise               = nan(num_quasars, 1);
 
@@ -61,41 +69,109 @@ z_list                   = 1:length(offset_samples_qso);
 fluxes                   = cell(length(z_list), 1);
 rest_wavelengths         = cell(length(z_list), 1);
 
-for quasar_ind = 1:num_quasars %quasar list
+% this is just an array allow you to select a range
+% of quasars to run
+quasar_ind = 1;
+q_ind_start = quasar_ind;
+
+% catch the exceptions
+all_exceptions = false(num_quasars, 1);
+
+for quasar_ind = q_ind_start:num_quasars %quasar list
     tic;
+    quasar_num = qso_ind(quasar_ind);
+    z_true(quasar_ind)   = z_qsos(quasar_num);
+
+    fprintf('processing quasar %i/%i (z_true = %0.4f) ...', ...
+        quasar_ind, num_quasars, z_true(quasar_ind));
+
+    %computing signal-to-noise ratio
+    this_wavelengths    =    all_wavelengths{quasar_num};
+    this_flux           =           all_flux{quasar_num};
+    this_noise_variance = all_noise_variance{quasar_num};
+    this_pixel_mask     =     all_pixel_mask{quasar_num};
+
+    this_rest_wavelengths = emitted_wavelengths(this_wavelengths, 4.4088); %roughly highest redshift possible (S2N for everything that may be in restframe)
+
+    ind  = this_rest_wavelengths <= max_lambda;
+
+    this_rest_wavelengths = this_rest_wavelengths(ind);
+    this_flux             =             this_flux(ind);
+    this_noise_variance   =   this_noise_variance(ind);
+
+    this_noise_variance(isinf(this_noise_variance)) = .01; %kludge to fix bad data
     
-    this_wavelengths    =    all_wavelengths{quasar_ind};
-    this_flux           =           all_flux{quasar_ind};
-    this_noise_variance = all_noise_variance{quasar_ind};
-    this_pixel_mask     =     all_pixel_mask{quasar_ind};
+    this_pixel_signal_to_noise  = sqrt(this_noise_variance) ./ abs(this_flux);
+
+    % this is before pixel masking; nanmean to avoid possible NaN values
+    signal_to_noise(quasar_ind) = nanmean(this_pixel_signal_to_noise);
+
+    % move these outside the parfor to avoid constantly querying these large arrays
+    this_out_wavelengths    =    all_wavelengths{quasar_num};
+    this_out_flux           =           all_flux{quasar_num};
+    this_out_noise_variance = all_noise_variance{quasar_num};
+    this_out_pixel_mask     =     all_pixel_mask{quasar_num};
+
+    % Test: see if this spec is empty; this error handling line be outside parfor
+    % would avoid running lots of empty spec in parallel workers
+    if all(size(this_out_wavelengths) == [0 0])
+        all_exceptions(quasar_ind, 1) = 1;
+        continue;
+    end
         
-    parfor z_list_ind = 1:length(offset_samples_qso) %variant redshift in quasars
-        z_qso = offset_samples_qso(z_list_ind);
+    parfor i = 1:num_zqso_samples       %variant redshift in quasars
+        z_qso = offset_samples_qso(i);
         
-        %interpolate observations
-        max_observed_lambda = observed_wavelengths(max_lambda, z_qso);
-        max_observed_lambda = min(max_observed_lambda, max(this_wavelengths));
-        min_observed_lambda = observed_wavelengths(min_lambda, z_qso);
-        min_observed_lambda = max(min_observed_lambda, min(this_wavelengths));
+        % keep a copy inside the parfor since we are modifying them
+        this_wavelengths    = this_out_wavelengths;
+        this_flux           = this_out_flux;
+        this_noise_variance = this_out_noise_variance;
+        this_pixel_mask     = this_out_pixel_mask;
+        
+        %Cut off observations
+        max_pos_lambda = observed_wavelengths(max_lambda, z_qso);
+        min_pos_lambda = observed_wavelengths(min_lambda, z_qso);
+        max_observed_lambda = min(max_pos_lambda, max(this_wavelengths));
+
+        min_observed_lambda = max(min_pos_lambda, min(this_wavelengths));
+        lambda_observed = (max_observed_lambda - min_observed_lambda);
+
+        ind = (this_wavelengths > min_observed_lambda) & (this_wavelengths < max_observed_lambda);
+        this_flux           = this_flux(ind);
+        this_noise_variance = this_noise_variance(ind);
+        this_wavelengths    = this_wavelengths(ind);
+        this_pixel_mask     = this_pixel_mask(ind);
+
         % convert to QSO rest frame
         this_rest_wavelengths = emitted_wavelengths(this_wavelengths, z_qso);
+        
+        %normalizing here
+        ind = (this_rest_wavelengths >= normalization_min_lambda) & ...
+            (this_rest_wavelengths <= normalization_max_lambda);
+
+        this_median         = nanmedian(this_flux(ind));
+        this_flux           = this_flux / this_median;
+        this_noise_variance = this_noise_variance / this_median .^ 2;
         
         ind = (this_rest_wavelengths >= min_lambda) & ...
             (this_rest_wavelengths <= max_lambda);
         
-        if (min_observed_lambda > max_observed_lambda) | (nnz(ind) < 150)
-            % If we have no data in the observed range, this sample is maximally unlikely.
-            sample_log_posteriors(quasar_ind, z_list_ind) = -1.e50;
-            continue;
-        end
-        %ind = ind & (~this_pixel_mask);
+        % if (min_observed_lambda > max_observed_lambda) | (nnz(ind) < 150)
+        %     % If we have no data in the observed range, this sample is maximally unlikely.
+        %     sample_log_posteriors(quasar_ind, i) = -1.e50;
+        %     continue;
+        % end
+        ind = ind & (~this_pixel_mask);
         
+        this_wavelengths      =      this_wavelengths(ind);
         this_rest_wavelengths = this_rest_wavelengths(ind);
-        this_rest_flux             =             this_flux(ind);
-        this_rest_noise_variance   =   this_noise_variance(ind);
+        this_flux             =             this_flux(ind);
+        this_noise_variance   =   this_noise_variance(ind);
+
+        this_noise_variance(isinf(this_noise_variance)) = nanmean(this_noise_variance); %rare kludge to fix bad data
         
-        fluxes{z_list_ind} = this_rest_flux;
-        rest_wavelengths{z_list_ind} = this_rest_wavelengths;
+        fluxes{i}           = this_flux;
+        rest_wavelengths{i} = this_rest_wavelengths;
         
         % interpolate model onto given wavelengths
         this_mu = mu_interpolator( this_rest_wavelengths);
@@ -106,20 +182,23 @@ for quasar_ind = 1:num_quasars %quasar list
        
         sample_log_priors = 0;
         
-        sample_log_posteriors(quasar_ind, z_list_ind) = ...
-            log_mvnpdf_low_rank(this_rest_flux, this_mu, this_M, this_rest_noise_variance) + sample_log_priors;
-        % Correct for incomplete data
-        corr = nnz(ind) - length(this_rest_wavelengths);
-        sample_log_posteriors(quasar_ind, z_list_ind) = sample_log_posteriors(quasar_ind, z_list_ind) + corr;
+        sample_log_posteriors(quasar_ind, i) = ...
+            log_mvnpdf_low_rank(this_flux, this_mu, this_M, this_noise_variance) + sample_log_priors;
 
-        fprintf_debug(' ... log p(D | z_QSO)     : %0.2f\n', ...
-            sample_log_posteriors(quasar_ind, z_list_ind));
+        % % Correct for incomplete data
+        % corr = nnz(ind) - length(this_rest_wavelengths);
+        % sample_log_posteriors(quasar_ind, i) = sample_log_posteriors(quasar_ind, i) + corr;
+
+        % fprintf_debug(' ... log p(D | z_QSO)     : %0.2f\n', ...
+        %     sample_log_posteriors(quasar_ind, i));
     end
     this_sample_log = sample_log_posteriors(quasar_ind, :);
     
-    [~, I] = max(this_sample_log);
+    [~, I] = nanmax(this_sample_log);
     
     z_map(quasar_ind) = offset_samples_qso(I);                                  %MAP estimate
+
+    fprintf(' took %0.3fs.\n', toc);
     
     zdiff = z_map(quasar_ind) - z_qsos(quasar_ind);
     if mod(quasar_ind, 1) == 0
@@ -131,7 +210,7 @@ end
 
 % save results
 variables_to_save = {'training_release', 'training_set_name', 'offset_samples_qso', 'sample_log_posteriors', ...
-     'z_map', 'z_qsos', 'all_thing_ids'};
+     'z_map', 'z_qsos', 'all_thing_ids', 'test_ind', 'z_true'};
 
 filename = sprintf('%s/processed_zqso_only_qsos_%s-%s', ...
     processed_directory(release), ...

--- a/set_parameters.m
+++ b/set_parameters.m
@@ -47,14 +47,14 @@ loading_max_lambda = 5000;                  % This maximum is set so we include 
 % quasar still has data in the range
 
 % preprocessing parameters
-z_qso_cut      = 0;         % filter out QSOs with z less than this threshold
+z_qso_cut      = 2.15;         % filter out QSOs with z less than this threshold
 z_qso_training_max_cut = 5; % roughly 95% of training data occurs before this redshift; assuming for normalization purposes (move to set_parameters when pleased)
 z_qso_training_min_cut = 1.5; % Ignore these quasars when training
 min_num_pixels = 300;                         % minimum number of non-masked pixels
 
 % normalization parameters
 normalization_min_lambda = lya_wavelength;              % range of rest wavelengths to use   Å
-normalization_max_lambda = lya_wavelength + 500; %   for flux normalization
+normalization_max_lambda = 1300; %   for flux normalization
 
 % null model parameters
 min_lambda         = lya_wavelength;                 % range of rest wavelengths to       Å


### PR DESCRIPTION
Adding features:

- Adding the runtime normalization to the learning and processing codes
- Adding some bool arrays to handle the empty spectra
- Before applying pca, making NaNs in the spectra to be the median of the given spectrum

Bug fixed:

- `offset_samples_qso` was not correctly generated before due to
  1. `z_qso_cut` was 0 but should be 2.15 in the `set_parameters.m`
  2. `offset_samples_qso` should be generated by Halton sequence. Now I change the runtime `offset_samples_qso` generation using the same code as in the `generate_dla_samples.m` script