### PR TITLE
Remove z_qso_training_min_cut and not normalize the flux in preload_qsos.m

### DIFF
--- a/learn_qso_model.m
+++ b/learn_qso_model.m
@@ -110,14 +110,6 @@ num_quasars = numel(z_qsos);
 
 fprintf('Get rid of empty spectra, num_quasars = %i\n', num_quasars);
 
-% Filter out spectra with redshifts outside the training region
-ind = (z_qsos > z_qso_training_min_cut) & (z_qsos < z_qso_training_max_cut);
-
-fprintf("Filtering %g quasars for redshift\n", length(rest_fluxes) - nnz(ind));
-
-rest_fluxes          = rest_fluxes(ind, :);
-rest_noise_variances = rest_noise_variances(ind,:);
-
 % mask noisy pixels
 ind = (rest_noise_variances > max_noise_variance);
 

--- a/preload_qsos.m
+++ b/preload_qsos.m
@@ -28,24 +28,12 @@ for i = 1:num_quasars
   ind = (this_wavelengths >= (min_lambda * (z_qso_cut) + 1)) & ...
         (this_wavelengths <= (max_lambda * (z_qso_training_max_cut) + 1)) & ...
         (~this_pixel_mask);
-  %{
-  ind = (this_rest_wavelengths >= min_lambda) & ...
-        (this_rest_wavelengths <= max_lambda) & ...
-        (~this_pixel_mask);
-  %}
+
   % bit 3: not enough pixels available
   if (nnz(ind) < min_num_pixels)
     filter_flags(i) = bitset(filter_flags(i), 4, true);
     continue;
   end
-
-  ind = (this_wavelengths >= (loading_min_lambda * (z_qso_cut) + 1)) & ...
-        (this_wavelengths <= (loading_max_lambda * (z_qso_training_max_cut) + 1));
-
-  % add one pixel on either side
-  available_ind = find(~ind & ~this_pixel_mask);
-  ind(min(available_ind(available_ind > find(ind, 1, 'last' )))) = true;
-  ind(max(available_ind(available_ind < find(ind, 1, 'first')))) = true;
 
   all_wavelengths{i}    =    this_wavelengths;%no longer (ind)
   all_flux{i}           =           this_flux;

--- a/preload_qsos.m
+++ b/preload_qsos.m
@@ -23,29 +23,7 @@ for i = 1:num_quasars
   [this_wavelengths, this_flux, this_noise_variance, this_pixel_mask] ...
       = file_loader(plates(i), mjds(i), fiber_ids(i));
 
-  % normalize flux
-
-  ind = (this_wavelengths >= normalization_min_lambda * (z_qso_cut) + 1) & ... // min allowable in observer frame
-        (this_wavelengths <= normalization_max_lambda * (z_qso_training_max_cut) + 1) & ... //max allowable in observer frame
-        (~this_pixel_mask);
-  medfiltwidth = (normalization_max_lambda - normalization_min_lambda)/dlambda;
-  this_norm = nanmax(medfilt1(this_flux(ind), medfiltwidth, 'omitnan', 'truncate'));
-
-  %{
-  this_rest_wavelengths = emitted_wavelengths(this_wavelengths, z_qsos(i));
-  ind = (this_rest_wavelengths >= normalization_min_lambda) & ... // min possible in observer frame
-        (this_rest_wavelengths <= normalization_max_lambda) & ...
-        (~this_pixel_mask);
-  this_norm = nanmedian(this_flux(ind));
-  this_hold(i) = min(this_rest_wavelengths);
-  %}
-
-  % bit 2: cannot normalize (all normalizing pixels are masked)
-  if (isnan(this_norm))
-    filter_flags(i) = bitset(filter_flags(i), 3, true);
-    continue;
-  end
-
+  % do not normalize flux: this is done in the learning and processing code.
 
   ind = (this_wavelengths >= (min_lambda * (z_qso_cut) + 1)) & ...
         (this_wavelengths <= (max_lambda * (z_qso_training_max_cut) + 1)) & ...
@@ -61,19 +39,9 @@ for i = 1:num_quasars
     continue;
   end
 
-  all_normalizers(i) = this_norm;
-
-  this_flux           = this_flux           / this_norm;
-  this_noise_variance = this_noise_variance / this_norm^2;
-
-
   ind = (this_wavelengths >= (loading_min_lambda * (z_qso_cut) + 1)) & ...
         (this_wavelengths <= (loading_max_lambda * (z_qso_training_max_cut) + 1));
 
-  %{
-  ind = (this_rest_wavelengths >= loading_min_lambda) & ...
-        (this_rest_wavelengths <= loading_max_lambda);
-  %}
   % add one pixel on either side
   available_ind = find(~ind & ~this_pixel_mask);
   ind(min(available_ind(available_ind > find(ind, 1, 'last' )))) = true;

--- a/set_parameters.m
+++ b/set_parameters.m
@@ -41,15 +41,14 @@ train_ind = ...
 test_set_name = 'dr12q';
 
 % file loading parameters
-loading_min_lambda = lya_wavelength;                % range of rest wavelengths to load  Å
-loading_max_lambda = 5000;                  % This maximum is set so we include CIV.
+loading_min_lambda = lya_wavelength;          % range of rest wavelengths to load  Å
+loading_max_lambda = 5000;                    % This maximum is set so we include CIV.
 % The maximum allowed is set so that even if the peak is redshifted off the end, the
 % quasar still has data in the range
 
 % preprocessing parameters
-z_qso_cut      = 2.15;         % filter out QSOs with z less than this threshold
-z_qso_training_max_cut = 5; % roughly 95% of training data occurs before this redshift; assuming for normalization purposes (move to set_parameters when pleased)
-z_qso_training_min_cut = 1.5; % Ignore these quasars when training
+z_qso_cut      = 2.15;                        % filter out QSOs with z less than this threshold
+z_qso_training_max_cut = 5;                   % roughly 95% of training data occurs before this redshift; assuming for normalization purposes (move to set_parameters when pleased)
 min_num_pixels = 400;                         % minimum number of non-masked pixels
 
 % normalization parameters
@@ -58,9 +57,9 @@ normalization_min_lambda = 1216 - 40;              % range of rest wavelengths t
 normalization_max_lambda = 1216 + 40;              %   for flux normalization
 
 % null model parameters
-min_lambda         = lya_wavelength - 40;                 % range of rest wavelengths to       Å
-max_lambda         = 3000;                 %   model
-dlambda            = 0.25;                 % separation of wavelength grid      Å
+min_lambda         =  910;                    % range of rest wavelengths to       Å
+max_lambda         = 3000;                    %   model
+dlambda            = 0.25;                    % separation of wavelength grid      Å
 k                  = 20;                      % rank of non-diagonal contribution
 max_noise_variance = 4^2;                     % maximum pixel noise allowed during model training
 
@@ -69,7 +68,7 @@ minFunc_options =               ...           % optimization options for model f
     struct('MaxIter',     4000, ...
            'MaxFunEvals', 8000);
 
-num_zqso_samples     = 10000;                  % number of parameter samples
+num_zqso_samples     = 10000;                 % number of parameter samples
 
 % base directory for all data
 base_directory = 'data';


### PR DESCRIPTION
Previously I ran the `preload_qsos.m` in my jibanCat/zestimation branch, but I did not update the version in jibanCat/zoutdata. The updated version is the same as the one in zqsos2. Now we should have a consistent preload_qsos.m across zqsos2 and zestimation.

Modifications:
----
- `learn_qso_model.m`: remove the "redshifts outside the training region" filter
- `preload_qsos.m`: don't normalize the flux
- `preload_qsos.m`: remove unused `available_ind` variable
- `set_parameters.m`: min_lambda 1176 -> 910